### PR TITLE
feat: add standalone SCPI transport library

### DIFF
--- a/ScpiTransport/ScpiClient.cs
+++ b/ScpiTransport/ScpiClient.cs
@@ -1,0 +1,744 @@
+﻿/*
+------------------------------------------------------------
+Oscilloscope Waveform Analyzer by ElmüSoft (www.netcult.ch/elmue)
+This code is released under the terms of the GNU General Public License.
+------------------------------------------------------------
+ 
+NAMING CONVENTIONS which allow to see the type of a variable immediately without having to jump to the variable declaration:
+ 
+     cName  for class    definitions
+     tName  for type     definitions
+     eName  for enum     definitions
+     kName  for "konstruct" (struct) definitions (letter 's' already used for string)
+   delName  for delegate definitions
+
+    b_Name  for bool
+    c_Name  for Char, also Color
+    d_Name  for double
+    e_Name  for enum variables
+    f_Name  for function delegates, also float
+    i_Name  for instances of classes
+    k_Name  for "konstructs" (struct) (letter 's' already used for string)
+	r_Name  for Rectangle
+    s_Name  for strings
+    o_Name  for objects
+ 
+   s8_Name  for   signed  8 Bit (sbyte)
+  s16_Name  for   signed 16 Bit (short)
+  s32_Name  for   signed 32 Bit (int)
+  s64_Name  for   signed 64 Bit (long)
+   u8_Name  for unsigned  8 Bit (byte)
+  u16_Name  for unsigned 16 bit (ushort)
+  u32_Name  for unsigned 32 Bit (uint)
+  u64_Name  for unsigned 64 Bit (ulong)
+
+  An additional "m" is prefixed for all member variables (e.g. ms_String)
+*/ 
+
+// --------------------------------------------------------------
+
+// 中文说明：本文件提供 SCPI 通信的统一入口，抽象出 USB/VXI/TCP 三种链路模式供上层复用。
+
+// Writes debug output to the debugger (or SysInternals DbgView)
+// See file "Logfile SCPI Commands DS1074Z.txt" in subfolder "Documentation" which shows a successful communication.
+#if DEBUG
+//   #define TRACE_OUTPUT
+#endif
+
+// --------------------------------------------------------------
+
+using System;
+using System.IO;
+using System.Net;
+using System.Net.Sockets;
+using System.Diagnostics;
+using System.Collections.Generic;
+using System.Text;
+using System.Globalization;
+using System.ComponentModel;
+using System.Threading;
+using System.Runtime.InteropServices;
+
+namespace ScpiTransport
+{
+    /// <summary>
+    /// 统一封装 USB/VXI/TCP 三种链路下的 SCPI 会话，免去对 NI-VISA 等大型驱动的依赖。
+    /// This class implements the TMC (Test and Measurement Class)
+    /// using the SCPI protocol (Standard Command for Programmable Instruments) over USB.
+    /// https://en.wikipedia.org/wiki/Standard_Commands_for_Programmable_Instruments
+    /// 
+    /// SCPI is an additional layer on top of the IEEE 488.2 specification.
+    /// See subfolder "Documentation" for more details.
+    /// 
+    /// All commands and responses are ASCII text. Only the command :WAVEFORM may be configured to return binary data.
+    /// 
+    /// You can enable TRACE_OUTPUT in this class to see debug output of the entire USB communication.
+    /// 
+    /// This class has not been designed to be thread safe.
+    /// 
+    /// This class makes it unnecessary to install huge software packets of one gigabyte from NI, IVI, Tektronix
+    /// or the huge Rigol UltraSigma which is bad quality primitive software.
+    /// 
+    /// Only the tiny IVI USB driver of 24 kilobyte size is required. (ausbtmc.sys)
+    /// It is included in this project.
+    /// 
+    /// This class communicates directly with the oscilloscope using the standard Windows API without any external dependencies. 
+    /// It implements non-blocking API calls using Overlapped I/O which is controlled by a timeout.
+    /// No fancy C# "async Task" or "await" or "CancellationToken" are required here which you find other projects.
+    /// They would only bloat up the code to the double size and produce a lot of unnecessary thread switching.
+    /// By the way: USB High-Speed runs at 480 MBit/s and the communications is very fast. The wait time is a few millisconds.
+    /// 
+    /// This class has been written by a software developer with 45 years of experience in programming and cracking.
+    /// It has been tested with a Rigol DS1074Z, but it should also work with other brands, even with function generators, mulimeters, etc.
+    /// 
+    /// This class was inspired by klasyc/ScpiNet. However his code has several design errors, it was rewritten from scratch bu Elmü.
+    /// </summary>
+    public class ScpiClient : IDisposable
+    {
+        #region enums
+
+        /// <summary>
+        /// This enum is only used for transferring binary data from :WAVEFORM:DATA? over a TCP connection.
+        /// As SCPI is extremely primitive the only way to detect the last data packet is the Linefeed at the end.
+        /// Unlike for USB there is no struct kTmcHeader that has a flag indicating the last packet.
+        /// How to make sure that a byte of 0x0A within the binary data does not terminate the transmission?
+        /// This enum defines how to detect the end of the binary data for a TCP connection.
+        /// ATTENTION:
+        /// The option to receive data until a timeout is no option because it would make the transfer EXTREMELY slow.
+        /// </summary>
+        public enum eBinaryTCP
+        {
+            // It seems that the Rigol serie DS1000DE does not send linefeed bytes inside the binary data.
+            // At least the file "Rigol DS1000E Waveform Guide.htm" in subfolder Documentation says so:
+            // "....each byte should have a value of between 15 and 240."
+            // "The top of the LCD display of the scope represents byte value 25 and the bottom is 225."
+            // So it seems that they take care not to send linefeeds withinh the data.
+            // In this mode the transmission ends when a packet ends with a linefeed.
+            Linefeed,
+
+            // The Rigol serie DS1000Z definitely sends bytes of value 0x0A within the binary data.
+            // But the oscilloscope sends reliably the count of samples that are to be transmitted for the current configuration.
+            // In this mode the transmission ends when the given minimum count of bytes was received.
+            // Behind the last binary byte comes the linefeed and sometimes a completely useless padding byte.
+            // These are eliminated here.
+            MinSize,
+        }
+
+        public enum eConnectMode
+        {
+            USB = 0,
+            TCP = 1,
+            VXI = 2,
+        }
+
+        #endregion
+
+        #region TMC
+
+        enum eTmcMsgId : byte
+        {
+            DEV_DEP_MSG_OUT        = 1,
+            REQUEST_DEV_DEP_MSG_IN = 2,
+        }
+
+        /// <summary>
+        /// USB TMC frame header according to the TMC specification. It is sent with each read and write request.
+        /// See USBTMC specification in subfolder "Documentation".
+        /// </summary>
+        [StructLayout(LayoutKind.Sequential, Pack = 1)]
+        struct kTmcHeader 
+        {
+            public eTmcMsgId e_MsgID;   // Byte  0
+            public byte u8_Tag;         // Byte  1  = Counter, must always be > 0
+            public byte u8_TagInverse;  // Byte  2  = One's complement of Tag
+            public byte u8_Reserved1;   // Byte  3  = must be 0
+            public int  s32_DataLen;    // Byte 4-7 = sent or requested data length, not including header and padding
+            public byte u8_Attributes;  // Byte  8  = meaning depends on e_MsgID
+            public byte u8_TermChar;    // Byte  9  = optional termination character (not used)
+            public byte u8_Reserved2;   // Byte 10  = must be 0
+            public byte u8_Reserved3;   // Byte 11  = must be 0
+        }
+       
+        const int SIZE_OF_TMC_HEADER = 12;   // Expected size of kTmcHeader (if compiled correctly) Never change this.
+        const int DEFAULT_TIMEOUT    = 1000; // milliseconds (This is far more than enough. Usb High-Speed runs at 480 MBit/s)
+
+        #endregion
+
+        // 128 byte buffer is sufficient for all SCPI commands that return an ASCII response 
+        const int BUF_SIZE_ASCII = 128;
+
+        // The default timeout for TCP connection is 20 seconds which is much too long.
+        const int TCP_CONNECT_TIMEOUT = 1500;
+        const int WSAETIMEDOUT        = 10060; // SocketException
+
+        eConnectMode me_Mode;
+        Byte         mu8_Tag; 
+        int          ms32_OpcReplaceDelay;
+        IntPtr       mp_HeaderMem;
+        UsbTmcDevice mi_UsbDevice;
+        Socket       mi_TcpSocket;
+        Vxi11Client  mi_VxiClient;
+
+        /// <summary>
+        /// A delay which replaces the *OPC? command.
+        /// For devices that do not support the command *OPC? it is required to make a fix delay which gives the device
+        /// the required time to process the command. If you set OpcReplaceDelay = 100 and then call SendOpcCommand()
+        /// the command will be sent and after a fix delay of 100 ms the funtion returns without
+        /// sending the command *OPC? and ignoring the timeout passed to SendOpcCommand().
+        /// If you set OpcReplaceDelay = 0 this delay is turned off and the command *OPC? will be sent instead.
+        /// </summary>
+        public int OpcReplaceDelay
+        {
+            set { ms32_OpcReplaceDelay = value; }
+        }
+
+        // =============================================================================================
+
+        /// <summary>
+        /// 连接 USB 模式的示波器，通常使用 <see cref="UsbDeviceEnumerator"/> 的返回值。
+        /// 构造函数内部直接打开符号链接并为后续 TMC 报文分配头部缓冲区。
+        /// </summary>
+        public void ConnectUsb(ScpiDeviceInfo deviceInfo)
+        {
+            if (deviceInfo == null)
+            {
+                throw new ArgumentNullException(nameof(deviceInfo));
+            }
+
+            #if TRACE_OUTPUT
+                Debug.Print("Open USB device \"" + deviceInfo + "\"");
+            #endif
+
+            Debug.Assert(Marshal.SizeOf(typeof(kTmcHeader)) == SIZE_OF_TMC_HEADER, "struct compilation error");
+
+            me_Mode      = eConnectMode.USB;
+            mi_UsbDevice = new UsbTmcDevice(deviceInfo);
+            mp_HeaderMem = Marshal.AllocHGlobal(SIZE_OF_TMC_HEADER);
+        }
+
+        /// <summary>
+        /// s_Endpoint   = "192.168.0.240 : 618" --> Connect directly to the control port 618.
+        /// 通过 VXI-11 协议连接远端示波器，可直接指定端口或让端口映射器自动解析。
+        /// s_Endpoint   = "192.168.0.240"       --> Request the control port from the portmapper and connect to it.
+        /// s_DeviceName = "inst0" for Rigol     ATTENTION: CASE SENSITIVE!
+        /// </summary>
+        public void ConnectVxi(String s_Endpoint, String s_DeviceName)
+        {
+            #if TRACE_OUTPUT
+                Debug.Print("Open VXI connection to " + s_Endpoint);
+            #endif
+
+            UInt16 u16_Port; // Port is allowed to be 0 here
+            IPAddress i_IpAddr = ParseEndpoint(s_Endpoint, out u16_Port);
+
+            me_Mode      = eConnectMode.VXI;
+            mi_VxiClient = new Vxi11Client();
+            mi_VxiClient.ConnectDevice(i_IpAddr, u16_Port);
+
+            mi_VxiClient.CreateLink(s_DeviceName);
+        }
+
+        /// <summary>
+        /// 基于裸 TCP Socket 建立 SCPI 连接，大多数以太网示波器都支持该模式。
+        /// </summary>
+        public void ConnectTcp(String s_Endpoint)
+        {
+            #if TRACE_OUTPUT
+                Debug.Print("Open TCP connection to " + s_Endpoint);
+            #endif
+
+            UInt16 u16_TcpPort;
+            IPAddress i_IpAddress = ParseEndpoint(s_Endpoint, out u16_TcpPort);
+
+            if (u16_TcpPort == 0)
+                Throw("Enter IP address and port separated by colon like: \"192.168.0.240 : 1234\"");
+
+            me_Mode      = eConnectMode.TCP;
+            mi_TcpSocket = ConnectTcpSocketAsync(i_IpAddress, u16_TcpPort);
+        }
+
+        /// <summary>
+        /// Parse enpoint string "192.168.0.240 : 618" into IP Address and port.
+        /// If the port is missing or invalid --> return u16_Port = 0.
+        /// If the IP Address is invalid --> throw exception
+        /// </summary>
+        IPAddress ParseEndpoint(String s_Endpoint, out UInt16 u16_Port)
+        {
+            u16_Port = 0;
+            String[] s_Parts = s_Endpoint.Split(':');
+
+            String s_IpAddress = s_Endpoint.Trim();
+            if (s_Parts.Length == 2)
+            {
+                s_IpAddress =   s_Parts[0].Trim();
+                UInt16.TryParse(s_Parts[1].Trim(), out u16_Port);
+            }
+            return IPAddress.Parse(s_IpAddress);
+        }
+
+        // =============================================================================================
+
+        /// <summary>
+        /// Finalizer (called on garbage collection)
+        /// </summary>
+        ~ScpiClient()
+        {
+            Dispose();
+        }
+
+        /// <summary>
+        /// IMPORTANT: This must be called before opening again.
+        /// </summary>
+        public void Dispose()
+        {
+            if (mi_UsbDevice != null)
+            {
+                #if TRACE_OUTPUT
+                    Debug.Print("Close USB device");
+                #endif
+                mi_UsbDevice.Dispose();
+                mi_UsbDevice = null;
+            }
+
+            if (mi_TcpSocket != null)
+            {
+                #if TRACE_OUTPUT
+                    Debug.Print("Close TCP connection");
+                #endif
+                mi_TcpSocket.Dispose();
+                mi_TcpSocket = null;
+            }
+
+            if (mi_VxiClient != null)
+            {
+                #if TRACE_OUTPUT
+                    Debug.Print("Close VXI connection");
+                #endif
+                mi_VxiClient.Dispose();
+                mi_VxiClient = null;
+            }
+
+            if (mp_HeaderMem != IntPtr.Zero)
+            {
+                Marshal.FreeHGlobal(mp_HeaderMem);
+                mp_HeaderMem = IntPtr.Zero;
+            }
+        }
+
+        // ================================ USB Communication ==========================================
+
+        /// <summary>
+        /// The command *OPC? queries if the last operation has finished. 
+        /// This can be used for all commands that do not return data, for example ":RUN"
+        /// 
+        /// The Rigol documentation says the scope returns "0" or "1".
+        /// But the Rigol oscilloscopes do not even comply their own documentation.
+        /// If the command ":AUTOSCALE" is still busy it never responds with "0".
+        /// It sends nothing until the command has finished calibrating the scope and then it responds "1", after 6 seconds!
+        /// A very long timeout is needed. Don't forget to show the wait cursor.
+        /// 
+        /// If OpcReplaceDelay has been set for devices that do not support the command *OPC?, a fix pause
+        /// of OpcReplaceDelay milliseconds will be made instead of sending the command *OPC? and s32_Timeout is ignored.
+        /// </summary>
+        public void SendOpcCommand(String s_Command, int s32_Timeout = 10000)
+        {
+            TransmitString(s_Command);
+
+            if (ms32_OpcReplaceDelay > 0)
+            {
+                #if TRACE_OUTPUT
+                    Debug.Print("Replace *OPC? with delay of "+ms32_OpcReplaceDelay+ " ms");
+                #endif
+
+                Thread.Sleep(ms32_OpcReplaceDelay);
+                return;
+            }
+
+            Stopwatch i_Watch = new Stopwatch();
+            i_Watch.Start();
+
+            while (true)
+            {
+                if (i_Watch.ElapsedMilliseconds > s32_Timeout)
+                {
+                    // ATTENTION:
+                    // This is EXTREMELY important! If it is missing you get TIMEOUT's again and again
+                    if (mi_UsbDevice != null)
+                        mi_UsbDevice.CancelTransfer();
+
+                    Throw("The SCPI command did not execute within the timeout.", true);
+                }
+
+                String s_Status = SendStringCommand("*OPC?", s32_Timeout);
+                if (s_Status == "1")
+                    break;
+
+                Thread.Sleep(200); // in case a "0" is received.
+            }
+        }
+
+        // ----------------------------------------
+
+        /// <summary>
+        /// Send an ASCII command and return a double
+        /// </summary>
+        public double SendDoubleCommand(String s_Command, int s32_Timeout = DEFAULT_TIMEOUT)
+        {
+            String s_Float = SendStringCommand(s_Command, s32_Timeout);
+
+            // On a German Windows doubles and floats use comma instead of dot!
+            double d_Value;
+            if (!Double.TryParse(s_Float, NumberStyles.Float, CultureInfo.InvariantCulture, out d_Value))
+                Throw("The oscilloscope has returned an invalid floating point value: " + s_Float);
+
+            return d_Value;
+        }
+
+        /// <summary>
+        /// Send an ASCII command and return a bool
+        /// </summary>
+        public bool SendBoolCommand(String s_Command, int s32_Timeout = DEFAULT_TIMEOUT)
+        {
+            String s_Status = SendStringCommand(s_Command, s32_Timeout);
+            return s_Status == "1" || s_Status == "ON";
+        }
+
+        /// <summary>
+        /// Send an ASCII command and return a string
+        /// </summary>
+        public String SendStringCommand(String s_Command, int s32_Timeout = DEFAULT_TIMEOUT)
+        {
+            TransmitString(s_Command, s32_Timeout);
+            String s_Response = ReceiveString(s32_Timeout);
+
+            // Debug.Print(String.Format("'{0}' --> '{1}'", s_Command, s_Response));
+            return s_Response;
+        }
+
+        /// <summary>
+        /// Send an ASCII command and return a byte array.
+        /// ATTENTION: If s32_BlockSize is too small to receive the ENTIRE response, the USB communication will crash.
+        /// s32_Timeout = timeout used for sending and for receiving one chunk
+        /// </summary>
+        public Byte[] SendByteCommand(eBinaryTCP e_BinaryTcp, int s32_BlockSize, String s_Command, int s32_Timeout = DEFAULT_TIMEOUT)
+        {
+            TransmitString(s_Command, s32_Timeout);
+
+            #if TRACE_OUTPUT
+                Debug.Print(">> SendByteCommand() timeout= "+s32_Timeout);
+            #endif
+
+            Byte[] u8_Data = null;
+            switch (me_Mode)
+            {
+                case eConnectMode.VXI: u8_Data = mi_VxiClient.DeviceRead(s32_Timeout);   break;
+                case eConnectMode.USB: u8_Data = ReceiveUsb(s32_BlockSize, s32_Timeout); break;
+                case eConnectMode.TCP: u8_Data = ReceiveTcp(e_BinaryTcp, s32_BlockSize, s32_Timeout); break;
+            }
+
+            #if TRACE_OUTPUT
+                Debug.Print("<< SendByteCommand() response= {0:N0} byte", u8_Data.Length);
+            #endif
+            return u8_Data;
+        }
+
+        // ==================================== PRIVATE =====================================
+
+        private void TransmitString(String s_Command, int s32_Timeout = DEFAULT_TIMEOUT)
+        {
+            #if TRACE_OUTPUT
+                if (s_Command != "*OPC?") Debug.Print("-------------------------------");
+                Debug.Print(">> TransmitString() command= \"" + s_Command + "\"");
+            #endif
+
+            Byte[] u8_TxCommand = Encoding.ASCII.GetBytes(s_Command + '\n');
+            switch (me_Mode)
+            {
+                case eConnectMode.VXI: mi_VxiClient.DeviceWrite(u8_TxCommand); break;
+                case eConnectMode.USB: SendUsbPacket    (u8_TxCommand, 0, s32_Timeout); break;
+                case eConnectMode.TCP: mi_TcpSocket.Send(u8_TxCommand, 0, u8_TxCommand.Length, SocketFlags.None); break;
+            }
+        
+            #if TRACE_OUTPUT
+                Debug.Print("<< TransmitString() finished");
+            #endif
+        }
+
+        private String ReceiveString(int s32_Timeout = DEFAULT_TIMEOUT)
+        {
+            #if TRACE_OUTPUT
+                Debug.Print(">> ReceiveString() timeout= "+s32_Timeout);
+            #endif
+
+            Byte[] u8_RxData = null;
+            switch (me_Mode)
+            {
+                case eConnectMode.VXI: u8_RxData = mi_VxiClient.DeviceRead(s32_Timeout); break;
+                case eConnectMode.USB: u8_RxData = ReceiveUsb(BUF_SIZE_ASCII, s32_Timeout); break;
+                case eConnectMode.TCP: u8_RxData = ReceiveTcp(eBinaryTCP.Linefeed, 0, s32_Timeout); break;
+            }
+            String s_Response = Encoding.ASCII.GetString(u8_RxData);
+
+            // ATTENTION: There may be garbage behind the response: "1.000000e+09\nO"
+            int s32_LF = s_Response.IndexOf('\n');
+            if (s32_LF > 0)
+                s_Response = s_Response.Substring(0, s32_LF);
+
+            #if TRACE_OUTPUT
+                Debug.Print("<< ReceiveString() response= \"" + s_Response + "\"");
+            #endif
+            return s_Response;
+        }
+
+        // ================================== USB ===================================
+
+        /// <summary>
+        /// ATTENTION: If s32_MaxRxData is too small to receive the entire response, the USB communication will crash.
+        /// s32_Timeout is for a chunk of data received in one TMC frame.
+        /// USB High-Speed bulk data transfer is extremely fast: approx 100 kB in less than 20 ms.
+        /// </summary>
+        private Byte[] ReceiveUsb(int s32_MaxRxData, int s32_Timeout = DEFAULT_TIMEOUT)
+        {
+            Byte[] u8_RxBuffer = new Byte[s32_MaxRxData + SIZE_OF_TMC_HEADER];
+
+            MemoryStream i_Stream = new MemoryStream();
+
+            // This loop runs until the device sets the EndOfMessage bit.
+            // When requesting 100.000 bytes WaveForm data, Rigol sends one respone packet of 512 byte,
+            // then another TMC header with 99524 bytes which are received in one single block.
+            while (true)
+            {
+                // Request response from device
+                SendUsbPacket(null, s32_MaxRxData, s32_Timeout);
+
+                #if TRACE_OUTPUT
+                    Debug.Print("  >> Receive() requesting " + s32_MaxRxData + " data bytes ...");
+                #endif
+
+                // The IVI driver does not allow to call Receive() first to request only the TMC header and then again to read the data.
+                // This is no problem with other drivers, but you will screw up the entire communication when you try this here.
+                int s32_BytesRead = mi_UsbDevice.Receive(u8_RxBuffer, s32_Timeout);
+                if (s32_BytesRead < SIZE_OF_TMC_HEADER)
+                {
+                    Throw("The USB device has sent a crippled response of " + s32_BytesRead + " bytes.\n"
+                        + "This may happen if the receive buffer is too small.");
+                }
+                // Copy the first bytes of u8_RxBuffer into k_Header
+                Marshal.Copy(u8_RxBuffer, 0, mp_HeaderMem, SIZE_OF_TMC_HEADER);
+                kTmcHeader k_Header = (kTmcHeader)Marshal.PtrToStructure(mp_HeaderMem, typeof(kTmcHeader));
+
+                // The TMC USB specification says clearly that the reponse must meet the following criteria otherwise it is invalid.
+                // This is the only way to check in the primitve TMC protocol if valid data was received as there are no checksums or other methods.
+                // If any bytes remained in the driver's receive buffer from a previous aborted transfer, this is the only way to detect this.
+                // If any sloppy devices like Keysight multimeters do not set the Tag and so do not comply with these minimum requirements, 
+                // they are buggy crap and cannot be used with this class. Demand a firmware update from the vendor.
+                // Even such a sloppy company as Rigol sets the Tag correctly.
+                if (k_Header.e_MsgID       != eTmcMsgId.REQUEST_DEV_DEP_MSG_IN ||
+                    k_Header.u8_Tag        != mu8_Tag                          ||
+                    k_Header.u8_TagInverse != (Byte)(~mu8_Tag)                 ||
+                    k_Header.s32_DataLen   > s32_MaxRxData)
+                {
+                    Throw("The USB device has sent an invalid response header");
+                }
+
+                i_Stream.Write(u8_RxBuffer, SIZE_OF_TMC_HEADER, s32_BytesRead - SIZE_OF_TMC_HEADER);
+
+                bool b_EndOfMsg = (k_Header.u8_Attributes & 1) > 0;
+                #if TRACE_OUTPUT
+                    Debug.Print("  << Receive() response= " + s32_BytesRead + " bytes, EndOfMsg= " + b_EndOfMsg);
+                #endif
+
+                if (b_EndOfMsg)
+                    break;
+            }
+            return i_Stream.ToArray();
+        }
+
+        // ----------------------------------------
+
+        /// <summary>
+        /// ATTENTION: If s32_MaxRxData is too small to receive the entire response, the USB communication will crash.
+        /// u8_TxCommand != null --> u8_TxCommand is appended to the 12 byte header and sent in one or multiple Bulk OUT packets of 512 bytes
+        /// u8_TxCommand == null --> A response is requested from the device in a Bulk IN transfer
+        /// </summary>
+		private void SendUsbPacket(Byte[] u8_TxCommand, int s32_MaxRxData, int s32_Timeout)
+		{
+            bool b_Command = u8_TxCommand != null;
+            #if TRACE_OUTPUT
+                if (b_Command) Debug.Print("  >> SendUsbPacket() sending command (TxData= " + u8_TxCommand.Length + " byte)");
+                else           Debug.Print("  >> SendUsbPacket() requesting response (MaxRxData= " + s32_MaxRxData + " byte)");
+            #endif
+
+            // incremet counter, always > 0
+            mu8_Tag = (Byte)Math.Max(1, mu8_Tag + 1);
+
+            // Create the write header:
+            kTmcHeader k_Header    = new kTmcHeader();
+            k_Header.u8_Tag        = mu8_Tag;
+            k_Header.u8_TagInverse = (Byte)~mu8_Tag;
+
+            if  (b_Command) // Send Command
+            {
+                k_Header.e_MsgID       = eTmcMsgId.DEV_DEP_MSG_OUT; // (Device Dependent Command Message, sent on Bulk OUT)
+                k_Header.s32_DataLen   = u8_TxCommand.Length; // length of command, not including header + padding
+                k_Header.u8_Attributes = 1; // 1 = EOM = End Of Message --> all data is sent in one packet
+            }
+            else // Request IN transfer
+            {
+                k_Header.e_MsgID       = eTmcMsgId.REQUEST_DEV_DEP_MSG_IN; // (command sent on Bulk OUT requesting the device to send a response on Bulk-IN)
+                k_Header.s32_DataLen   = s32_MaxRxData; // maximum data length for the requested Bulk IN packet
+                k_Header.u8_Attributes = 0; // 0 = Device must ignore u8_TermChar
+            }
+
+            // Copy k_Header into u8_Header
+            Byte[] u8_Header = new Byte[SIZE_OF_TMC_HEADER];
+            Marshal.StructureToPtr(k_Header, mp_HeaderMem, false);
+            Marshal.Copy(mp_HeaderMem, u8_Header, 0, SIZE_OF_TMC_HEADER);
+
+            List<Byte> i_Transfer = new List<Byte>();
+            i_Transfer.AddRange(u8_Header);            
+            if (b_Command)
+                i_Transfer.AddRange(u8_TxCommand);
+
+            // align to 4 byte boundary
+            while ((i_Transfer.Count & 0x3) > 0) 
+            {
+                i_Transfer.Add(0);
+            }
+
+            mi_UsbDevice.Send(i_Transfer.ToArray(), s32_Timeout);
+
+            #if TRACE_OUTPUT
+                Debug.Print("  << SendUsbPacket() finished");
+            #endif
+        }
+
+        // ================================== TCP ===================================
+
+        /// <summary>
+        /// Microsoft forgot to implement a function Socket.Connect(int Timeout)
+        /// The default connect timeout is 20 seconds which is much too long --> Use TCP_CONNECT_TIMEOUT instead.
+        /// </summary>
+        public static Socket ConnectTcpSocketAsync(IPAddress i_IpAddress, UInt16 u16_TcpPort)
+        {
+            Socket i_TcpSocket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+            i_TcpSocket.ReceiveTimeout = 2000; // changed later
+            i_TcpSocket.SendTimeout    = 1000; // all commands are very short (< 50 byte)
+
+            ManualResetEvent     i_Event = new ManualResetEvent(false);
+            SocketAsyncEventArgs i_Args  = new SocketAsyncEventArgs();
+            i_Args.RemoteEndPoint = new IPEndPoint(i_IpAddress, u16_TcpPort);
+            i_Args.SocketError    = SocketError.TimedOut;
+            i_Args.Completed     += delegate(Object o_Sender, SocketAsyncEventArgs i_EvArgs)
+            {
+                i_Event.Set();
+            };
+
+            if (i_TcpSocket.ConnectAsync(i_Args) &&   // returns true if connection is pending
+               !i_Event.WaitOne(TCP_CONNECT_TIMEOUT)) // returns false on timeout
+                Throw("Could not connect to " + i_Args.RemoteEndPoint + "  (Timeout)");
+
+            if (i_Args.SocketError != SocketError.Success)
+                Throw("Could not connect to " + i_Args.RemoteEndPoint + "  (" + i_Args.SocketError + ")");
+
+            return i_TcpSocket;
+        }
+
+        /// <summary>
+        /// While for USB the struct kTmcHeader has a flag indicating the last packet,
+        /// over TCP no such information is available and the linefeed at the end is the only way to detect the end.
+        /// But the binary data may also contain multiple values of 0x0A within the data.
+        /// The oscilloscope sends the data in many separate packets. Rigol sends packets of 5840 bytes.
+        /// See comment of eBinaryTCP for more details.
+        /// s32_MinSize is only used in mode eBinaryTCP.MinSize
+        /// </summary>
+        private Byte[] ReceiveTcp(eBinaryTCP e_BinaryTcp, int s32_MinSize, int s32_Timeout)
+        {
+            #if TRACE_OUTPUT
+                if (e_BinaryTcp == eBinaryTCP.MinSize) Debug.Print("  >> ReceiveTcp(MinSize = {0:N0} byte)", s32_MinSize);
+                else                                   Debug.Print("  >> ReceiveTcp(Linefeed)");
+            #endif
+
+            MemoryStream i_Stream = new MemoryStream();
+            Byte[] u8_Buffer = new Byte[0x8000];
+
+            mi_TcpSocket.ReceiveTimeout = s32_Timeout;
+            while (true)
+            {
+                // s32_RxCount will never be zero. A timeout exception is thrown in case nothing was received.  
+                int s32_RxCount = 0;
+                try
+                {
+                    s32_RxCount = mi_TcpSocket.Receive(u8_Buffer, u8_Buffer.Length, SocketFlags.None);
+                }
+                catch (SocketException Ex)
+                {
+                    // In case of Timeout the SocketException must be converted into a TimeoutException. 
+                    if (Ex.ErrorCode == WSAETIMEDOUT)
+                        Throw("Timeout. No response from the oscilloscope.\nRead the Help file!", true);
+
+                    #if TRACE_OUTPUT
+                        Debug.Print("*** " + Ex.Message);
+                    #endif
+                    throw Ex;
+                }
+
+                #if TRACE_OUTPUT
+                    Debug.Print("     Rx block of {0} byte, Total Rx = {1:N0} byte", s32_RxCount, i_Stream.Length + s32_RxCount);
+                #endif
+                   
+                if (e_BinaryTcp == eBinaryTCP.Linefeed || 
+                   (e_BinaryTcp == eBinaryTCP.MinSize && i_Stream.Length + s32_RxCount >= s32_MinSize))
+                {
+                    // Abort when the block ends with linefeed.
+                    // ATTENTION: There may be padding bytes behind the linefeed.
+                    // The linefeed is not necessarily the last byte --> search the last 4 bytes for a linefeed.
+                    int s32_LF = FindByteReverse(u8_Buffer, s32_RxCount, 4, 0x0A);
+                    if (s32_LF > -1)
+                    {
+                        // Append all received bytes except the linefeed (and padding) at the end
+                        i_Stream.Write(u8_Buffer, 0, s32_LF);
+                        break;
+                    }
+                }
+
+                // Append the entire block, more data will follow.
+                i_Stream.Write(u8_Buffer, 0, s32_RxCount);
+            }
+
+            #if TRACE_OUTPUT
+                Debug.Print("  << ReceiveTcp() --> received {0:N0} bytes", i_Stream.Length);
+            #endif
+            return i_Stream.ToArray();
+        }
+
+        // ================================== Helper ====================================
+
+        /// <summary>
+        /// 在缓冲区中自后向前查找特定字节，便于定位 TCP 波形流中的结束符。
+        /// </summary>
+        static int FindByteReverse(Byte[] buffer, int count, int minIndex, byte value)
+        {
+            for (int index = count - 1; index >= minIndex; index--)
+            {
+                if (buffer[index] == value)
+                    return index;
+            }
+
+            return -1;
+        }
+
+        /// <summary>
+        /// 抛出统一的异常对象，遇到超时场景时改为 TimeoutException 以便上层区分。
+        /// </summary>
+        static void Throw(String s_Message, bool b_Timeout = false)
+        {
+            #if TRACE_OUTPUT
+                Debug.Print("*** " + s_Message);
+            #endif
+
+            if (b_Timeout) throw new TimeoutException(s_Message);
+            else           throw new Exception(s_Message);
+        }
+    }
+}

--- a/ScpiTransport/ScpiDeviceInfo.cs
+++ b/ScpiTransport/ScpiDeviceInfo.cs
@@ -1,0 +1,49 @@
+using System;
+
+namespace ScpiTransport
+{
+    /// <summary>
+    /// 表示一个可被 SCPI 会话使用的物理或逻辑设备路径。
+    /// </summary>
+    public sealed class ScpiDeviceInfo
+    {
+        /// <summary>
+        /// 设备在界面或日志中显示的友好名称。
+        /// </summary>
+        public string DisplayName { get; }
+
+        /// <summary>
+        /// 用于真正打开设备的底层路径，USB 模式为符号链接，其他模式可以是任意标识。
+        /// </summary>
+        public string DevicePath { get; }
+
+        /// <summary>
+        /// 初始化设备信息对象。
+        /// </summary>
+        /// <param name="displayName">供人阅读的名称，例如序列号。</param>
+        /// <param name="devicePath">系统调用所需的完整路径。</param>
+        public ScpiDeviceInfo(string displayName, string devicePath)
+        {
+            if (string.IsNullOrWhiteSpace(displayName))
+            {
+                throw new ArgumentException("displayName 不能为空", nameof(displayName));
+            }
+
+            if (string.IsNullOrWhiteSpace(devicePath))
+            {
+                throw new ArgumentException("devicePath 不能为空", nameof(devicePath));
+            }
+
+            DisplayName = displayName;
+            DevicePath  = devicePath;
+        }
+
+        /// <summary>
+        /// 返回用于界面显示的名称，便于直接绑定到列表控件。
+        /// </summary>
+        public override string ToString()
+        {
+            return DisplayName;
+        }
+    }
+}

--- a/ScpiTransport/ScpiTransport.csproj
+++ b/ScpiTransport/ScpiTransport.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>net48;net7.0-windows</TargetFrameworks>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <Nullable>disable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <Description>基于 SCPI 协议的示波器通信核心类库，支持 USB/VXI-11/TCP 多种传输方式。</Description>
+  </PropertyGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)'=='net48'">
+    <Reference Include="System.Management" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)'=='net7.0-windows'">
+    <PackageReference Include="System.Management" Version="7.0.0" />
+  </ItemGroup>
+</Project>

--- a/ScpiTransport/UsbDeviceEnumerator.cs
+++ b/ScpiTransport/UsbDeviceEnumerator.cs
@@ -1,0 +1,61 @@
+using System;
+using System.Collections.Generic;
+
+#if NET48 || NET7_0_WINDOWS
+using System.Management;
+#endif
+
+namespace ScpiTransport
+{
+    /// <summary>
+    /// 提供对符合 USB Test and Measurement Class (USBTMC) 设备的扫描能力。
+    /// 该实现直接依赖 WMI，因此仅在 Windows 平台可用。
+    /// </summary>
+    public static class UsbDeviceEnumerator
+    {
+        /// <summary>
+        /// USBTMC 设备在系统中的 Class GUID，Rigol、Keysight 等厂商都遵循该值。
+        /// </summary>
+        public const string UsbTmcClassGuid = "{A9FDBB24-128A-11D5-9961-00108335E361}";
+
+        /// <summary>
+        /// 扫描当前操作系统中所有已连接的 USBTMC 设备，并返回可用于建立 SCPI 会话的路径。
+        /// </summary>
+        /// <returns>可枚举的 <see cref="ScpiDeviceInfo"/> 列表。</returns>
+        /// <exception cref="PlatformNotSupportedException">当运行在非 Windows 平台时抛出。</exception>
+        public static IReadOnlyList<ScpiDeviceInfo> Enumerate()
+        {
+            var devices = new List<ScpiDeviceInfo>();
+
+#if NET48 || NET7_0_WINDOWS
+            using (var managementClass = new ManagementClass("Win32_PnPEntity"))
+            {
+                foreach (ManagementObject instance in managementClass.GetInstances())
+                {
+                    var classGuid = instance.GetPropertyValue("ClassGuid")?.ToString();
+                    if (!UsbTmcClassGuid.Equals(classGuid, StringComparison.OrdinalIgnoreCase))
+                    {
+                        continue;
+                    }
+
+                    var deviceId = instance.GetPropertyValue("PnpDeviceID")?.ToString();
+                    if (string.IsNullOrWhiteSpace(deviceId))
+                    {
+                        continue;
+                    }
+
+                    var symbolicLink = @"\\?\" + deviceId.Replace('\\', '#') + "#" + UsbTmcClassGuid;
+                    var parts        = deviceId.Split('\\');
+                    var serial       = parts.Length > 0 ? parts[parts.Length - 1].ToUpperInvariant() : deviceId;
+
+                    devices.Add(new ScpiDeviceInfo(serial, symbolicLink));
+                }
+            }
+#else
+            throw new PlatformNotSupportedException("当前平台不支持 USBTMC 枚举，仅 Windows 提供该能力。");
+#endif
+
+            return devices;
+        }
+    }
+}

--- a/ScpiTransport/UsbTmcTransport.cs
+++ b/ScpiTransport/UsbTmcTransport.cs
@@ -1,0 +1,248 @@
+using System;
+using System.ComponentModel;
+using System.Diagnostics;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Threading;
+
+namespace ScpiTransport
+{
+    /// <summary>
+    /// 通过 Windows USBTMC 驱动 (ausbtmc.sys) 直接访问示波器的封装。
+    /// 该类完全采用重叠 I/O，同步 API 仍然保持非阻塞特性。
+    /// </summary>
+    internal sealed class UsbTmcDevice : IDisposable
+    {
+        private static readonly IntPtr InvalidHandleValue = new IntPtr(-1);
+
+        private const int ErrorFileNotFound = 2;
+        private const int ErrorGenFailure  = 31;
+        private const int ErrorIoPending   = 997;
+        private const int WaitTimeout      = 258;
+
+        private IntPtr _handle;
+        private NativeOverlapped _overlapped;
+
+        /// <summary>
+        /// 构造函数会立即打开 USBTMC 设备句柄并创建事件对象。
+        /// </summary>
+        /// <param name="device">需要连接的设备信息。</param>
+        public UsbTmcDevice(ScpiDeviceInfo device)
+        {
+            if (device == null)
+            {
+                throw new ArgumentNullException(nameof(device));
+            }
+
+            _handle = CreateFileW(
+                device.DevicePath,
+                FileAccessFlags.GenericRead | FileAccessFlags.GenericWrite,
+                FileShareFlags.Read | FileShareFlags.Write,
+                IntPtr.Zero,
+                CreationDisposition.OpenExisting,
+                FileAttributeFlags.Overlapped,
+                IntPtr.Zero);
+
+            if (_handle == InvalidHandleValue)
+            {
+                var error = Marshal.GetLastWin32Error();
+                if (error == ErrorFileNotFound)
+                {
+                    throw new InvalidOperationException("USBTMC 设备不存在或已经被拔出。");
+                }
+
+                throw new Win32Exception(error);
+            }
+
+            _overlapped.EventHandle = CreateEventW(IntPtr.Zero, true, false, null);
+            if (_overlapped.EventHandle == IntPtr.Zero)
+            {
+                Dispose();
+                throw new Win32Exception(Marshal.GetLastWin32Error());
+            }
+        }
+
+        /// <summary>
+        /// 取消所有挂起的 I/O 操作，避免驱动在下一次访问时仍旧返回超时。
+        /// </summary>
+        public void CancelTransfer()
+        {
+            if (_handle != IntPtr.Zero)
+            {
+                CancelIo(_handle);
+            }
+        }
+
+        /// <summary>
+        /// 发送完整的 USB Bulk OUT 数据包。
+        /// </summary>
+        /// <param name="packet">需要发送的字节数组。</param>
+        /// <param name="timeout">等待驱动完成的超时时间，单位毫秒。</param>
+        public void Send(byte[] packet, int timeout)
+        {
+            if (packet == null)
+            {
+                throw new ArgumentNullException(nameof(packet));
+            }
+
+            CancelTransfer();
+
+            if (!WriteFile(_handle, packet, packet.Length, out var written, ref _overlapped))
+            {
+                var error = Marshal.GetLastWin32Error();
+                if (error != ErrorIoPending)
+                {
+                    throw new Win32Exception(error);
+                }
+
+                if (WaitForSingleObject(_overlapped.EventHandle, timeout) == WaitTimeout)
+                {
+                    CancelIo(_handle);
+                    throw new TimeoutException("发送 USBTMC 数据包超时，设备未在期望时间内响应。");
+                }
+
+                if (!GetOverlappedResult(_handle, ref _overlapped, out written, false))
+                {
+                    error = Marshal.GetLastWin32Error();
+                    if (error == ErrorGenFailure)
+                    {
+                        throw new InvalidOperationException("USB 设备当前不可用，通常发生在系统休眠恢复之后，请重新连接设备。");
+                    }
+
+                    throw new Win32Exception(error);
+                }
+            }
+
+            if (written != packet.Length)
+            {
+                throw new IOException("写入 USBTMC 数据时发生未知错误，已发送字节数与期望不一致。");
+            }
+        }
+
+        /// <summary>
+        /// 接收 USB Bulk IN 数据包。
+        /// </summary>
+        /// <param name="buffer">用于承载返回数据的缓冲区。</param>
+        /// <param name="timeout">等待设备返回的超时时间。</param>
+        /// <returns>实际读取到的字节数。</returns>
+        public int Receive(byte[] buffer, int timeout)
+        {
+            if (buffer == null)
+            {
+                throw new ArgumentNullException(nameof(buffer));
+            }
+
+            if (!ReadFile(_handle, buffer, buffer.Length, out var read, ref _overlapped))
+            {
+                var error = Marshal.GetLastWin32Error();
+                if (error != ErrorIoPending)
+                {
+                    throw new Win32Exception(error);
+                }
+
+                if (WaitForSingleObject(_overlapped.EventHandle, timeout) == WaitTimeout)
+                {
+                    Debug.Print("USB 读取超时");
+                    CancelIo(_handle);
+                    throw new TimeoutException("等待 USBTMC 设备返回数据超时，可能是命令无效或设备繁忙。");
+                }
+
+                if (!GetOverlappedResult(_handle, ref _overlapped, out read, false))
+                {
+                    throw new Win32Exception(Marshal.GetLastWin32Error());
+                }
+            }
+
+            return read;
+        }
+
+        /// <summary>
+        /// 释放句柄和事件资源。
+        /// </summary>
+        public void Dispose()
+        {
+            if (_overlapped.EventHandle != IntPtr.Zero)
+            {
+                CloseHandle(_overlapped.EventHandle);
+                _overlapped.EventHandle = IntPtr.Zero;
+            }
+
+            if (_handle != IntPtr.Zero && _handle != InvalidHandleValue)
+            {
+                CloseHandle(_handle);
+                _handle = IntPtr.Zero;
+            }
+        }
+
+        [Flags]
+        private enum FileAccessFlags : uint
+        {
+            GenericRead  = 0x80000000,
+            GenericWrite = 0x40000000,
+        }
+
+        [Flags]
+        private enum FileShareFlags : uint
+        {
+            Read  = 0x01,
+            Write = 0x02,
+        }
+
+        private enum CreationDisposition : uint
+        {
+            OpenExisting = 3,
+        }
+
+        [Flags]
+        private enum FileAttributeFlags : uint
+        {
+            None       = 0,
+            Overlapped = 0x40000000,
+        }
+
+        [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+        private static extern IntPtr CreateFileW(
+            string fileName,
+            FileAccessFlags desiredAccess,
+            FileShareFlags shareMode,
+            IntPtr securityAttributes,
+            CreationDisposition creationDisposition,
+            FileAttributeFlags flagsAndAttributes,
+            IntPtr templateFile);
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        private static extern bool CloseHandle(IntPtr handle);
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        private static extern bool ReadFile(
+            IntPtr handle,
+            byte[] buffer,
+            int numberOfBytesToRead,
+            out int numberOfBytesRead,
+            ref NativeOverlapped overlapped);
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        private static extern bool WriteFile(
+            IntPtr handle,
+            byte[] buffer,
+            int numberOfBytesToWrite,
+            out int numberOfBytesWritten,
+            ref NativeOverlapped overlapped);
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        private static extern bool GetOverlappedResult(
+            IntPtr handle,
+            ref NativeOverlapped overlapped,
+            out int numberOfBytesTransferred,
+            bool wait);
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        private static extern int WaitForSingleObject(IntPtr handle, int milliseconds);
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        private static extern bool CancelIo(IntPtr handle);
+
+        [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+        private static extern IntPtr CreateEventW(IntPtr lpEventAttributes, bool manualReset, bool initialState, string name);
+    }
+}

--- a/ScpiTransport/Vxi11Client.cs
+++ b/ScpiTransport/Vxi11Client.cs
@@ -1,0 +1,1084 @@
+﻿/*
+------------------------------------------------------------
+Oscilloscope Waveform Analyzer by ElmüSoft (www.netcult.ch/elmue)
+This code is released under the terms of the GNU General Public License.
+------------------------------------------------------------
+
+NAMING CONVENTIONS which allow to see the type of a variable immediately without having to jump to the variable declaration:
+ 
+     cName  for class    definitions
+     tName  for type     definitions
+     eName  for enum     definitions
+     kName  for "konstruct" (struct) definitions (letter 's' already used for string)
+   delName  for delegate definitions
+
+    b_Name  for bool
+    c_Name  for Char, also Color
+    d_Name  for double
+    e_Name  for enum variables
+    f_Name  for function delegates, also float
+    i_Name  for instances of classes
+    k_Name  for "konstructs" (struct) (letter 's' already used for string)
+	r_Name  for Rectangle
+    s_Name  for strings
+    o_Name  for objects
+ 
+   s8_Name  for   signed  8 Bit (sbyte)
+  s16_Name  for   signed 16 Bit (short)
+  s32_Name  for   signed 32 Bit (int)
+  s64_Name  for   signed 64 Bit (long)
+   u8_Name  for unsigned  8 Bit (byte)
+  u16_Name  for unsigned 16 bit (ushort)
+  u32_Name  for unsigned 32 Bit (uint)
+  u64_Name  for unsigned 64 Bit (ulong)
+
+  An additional "m" is prefixed for all member variables (e.g. ms_String)
+*/ 
+
+// --------------------------------------------------------------
+
+// 中文说明：本文件实现了 VXI-11 协议的核心 RPC 调度逻辑，可直接用于以太网上的示波器通信。
+
+// Writes TCP communication to the debugger (or SysInternals DbgView)
+#if DEBUG
+//    #define TRACE_OUTPUT
+#endif
+
+// --------------------------------------------------------------
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Net;
+using System.Net.Sockets;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading;
+
+namespace ScpiTransport
+{
+    /// <summary>
+    /// VXI-11 客户端，封装 RPC 连接、命令发送与响应解析的完整流程。
+    /// Implementation of the VXI-11 protocol.
+    /// https://www.scribd.com/document/217242183/VXI-11-spec
+    /// </summary>
+    public class Vxi11Client : IDisposable
+    {
+        #region enums
+
+        enum eMesgType
+        {
+            Call  = 0,
+            Reply = 1,
+        }
+
+        enum eProcedure
+        {
+            Device_Abort      =  1, // device aborts an in-progress call,   sent to abort channel
+            Get_Port          =  3, // device reports its core port,        sent to portmapper channel
+            Device_Intr_Srq   = 30, // device sends a service request,      sent to interrupt channel
+            // --------------------------------------------
+            // the following are sent to the core channel:
+            Create_Link       = 10, // opens a link to a device
+            Device_Write      = 11, // send command to device
+            Device_Read       = 12, // device sends reply
+            Device_Read_Stb   = 13, // device sends its status byte
+            Device_Trigger    = 14, // device executes a trigger
+            Device_Clear      = 15, // device clears itself
+            Device_Remote     = 16, // device disables its front panel
+            Device_Local      = 17, // device enables its front panel
+            Device_Lock       = 18, // lock device
+            Device_Unlock     = 19, // unlock device
+            Device_Enable_Srq = 20, // device enables/disables sending of service requests
+            Device_Do_Cmd     = 22, // device executes a command that is defined in eCommand
+            Destroy_Link      = 23, // closes a link to the device
+            Create_Intr_Chan  = 25, // device creates  interrupt channel
+            Destroy_Intr_Chan = 26, // device destroys interrupt channel
+        }
+
+        enum eCommand
+        {
+            Send_Command = 0x020000,
+            Bus_Status   = 0x020001,
+            ATN_Ctrl     = 0x020002,
+            REN_Ctrl     = 0x020003,
+            PASS_Ctrl    = 0x020004,
+            Bus_Address  = 0x02000A,
+            IFC_Ctrl     = 0x020010, // Interface Clear (reset GPIB bus devices)
+        }
+
+        enum eReplyState
+        {
+            Accepted = 0,
+            Denied,
+        }
+
+        enum eAcceptState
+        {
+            Success = 0,
+            Program_unavailable,
+            Program_version_mismatch,
+            Procedure_unavailable,
+            Invalid_arguments,
+            System_error,
+        }
+
+        enum eVxiError
+        {
+            Success                       =  0,
+            Syntax_Error                  =  1,
+            Device_not_accessible         =  3,
+            Invalid_link_identifier       =  4,
+            Parameter_error               =  5,
+            Channel_not_established       =  6,
+            Operation_not_supported       =  8,
+            Out_of_resources              =  9,
+            Device_locked_by_another_link = 11,
+            No_lock_held_by_this_link     = 12,
+            IO_Timeout                    = 15,
+            IO_Error                      = 17,
+            Invalid_address               = 21,
+            Aborted                       = 23, // Device_Abort has been sent to the Abort channel
+            Channel_already_established   = 29,
+        }
+
+        [FlagsAttribute]
+        enum eWriteFlags
+        {
+            None        = 0,
+            WaitLocked  = 0x01, // Wait until locked
+            End         = 0x08, // End of data
+            TermCharSet = 0x80, // Termination character set
+        }
+
+        [FlagsAttribute]
+        enum eReadFlags
+        {
+            None      = 0,    // The return buffer is full --> no flag shall be set
+            RequCount = 0x01, // Requested char count reached
+            TermChar  = 0x02, // Termination character has been transferred
+            End       = 0x04, // End of data
+        }
+
+        #endregion
+
+        #region ICmdParam
+
+        interface ICmdParam
+        {
+            int GetTxByteCount();
+        }
+
+        #endregion
+
+        #region VxiStream
+
+        /// <summary>
+        /// A big-endian MemoryStream
+        /// </summary>
+        class VxiStream : MemoryStream
+        {
+            public VxiStream()
+            {
+            }
+
+            /// <summary>
+            /// Write a big-endian integer to the stream
+            /// s_Debug = "Header"
+            /// </summary>
+            public void WriteInt32(int s32_Value, String s_Debug)
+            {
+                #if TRACE_OUTPUT
+                    TraceLine("Write", 4, s_Debug, s32_Value.ToString("X8"));
+                #endif
+
+                WriteByte((Byte)(s32_Value >> 24));
+                WriteByte((Byte)(s32_Value >> 16));
+                WriteByte((Byte)(s32_Value >>  8));
+                WriteByte((Byte)(s32_Value));
+            }
+
+            /// <summary>
+            /// Read a big-endian integer from the stream
+            /// s_Debug = "Port", "ErrorFlags"
+            /// </summary>
+            public int ReadInt32(String s_Debug)
+            {
+                int s32_Value = 0;
+                for (int i=0; i<4; i++)
+                {
+                    int s32_Byte = ReadByte();
+                    if (s32_Byte < 0)
+                        Throw("Insufficient bytes received");
+
+                    s32_Value <<= 8;
+                    s32_Value  |= s32_Byte;
+                }
+
+                #if TRACE_OUTPUT
+                    TraceLine("Read", 4, s_Debug, s32_Value.ToString("X8"));
+                #endif
+                return s32_Value;
+            }
+
+            // ======================================================================================
+
+            /// <summary>
+            /// Write a structure or class to the stream
+            /// ATTENTION: All integers in the struct must be big endian!
+            /// </summary>
+            public void WriteStruct(ICmdParam i_Param)
+            {
+                int    s32_Size = Marshal.SizeOf(i_Param.GetType());
+                Byte[] u8_Bytes = new Byte[s32_Size];
+                IntPtr p_Mem    = Marshal.AllocHGlobal(s32_Size);
+
+                Marshal.StructureToPtr(i_Param, p_Mem, false);
+                Marshal.Copy(p_Mem, u8_Bytes, 0, s32_Size);
+                Marshal.FreeHGlobal(p_Mem);
+
+                // If the class i_Param has an ASCII string, only the part of u8_Bytes is sent that has valid data.
+                int s32_ByteCount = i_Param.GetTxByteCount();
+                #if TRACE_OUTPUT
+                    TraceLine("Write", s32_ByteCount, i_Param.GetType().Name, BytesToHex(u8_Bytes, s32_ByteCount));
+                #endif
+                Write(u8_Bytes, 0, s32_ByteCount);
+            }
+
+            /// <summary>
+            /// Read a structure or class from the stream
+            /// ATTENTION: All integers in the struct are big endian!
+            /// </summary>
+            public T ReadStruct<T>()
+            {
+                int s32_Size = Marshal.SizeOf(typeof(T));
+                Byte[] u8_Bytes = new Byte[s32_Size];
+                int    s32_Read = Read(u8_Bytes, 0, s32_Size);
+
+                #if TRACE_OUTPUT
+                    TraceLine("Read", s32_Size, typeof(T).Name, BytesToHex(u8_Bytes, s32_Read));
+
+                    // In case of an error it may happen that the device sends an incomplete response 
+                    // which contains only the first integer after the RPC struct: ms32_ErrorCode.
+                    // The remaining members in the struct will be left zero.
+                    if (s32_Read != s32_Size)
+                        Debug.Print("   *** Received {0} instead of {1} bytes", s32_Read, s32_Size);
+                #endif
+
+                if (s32_Read < 4)
+                    Throw("Empty response received");
+
+                IntPtr p_Mem = Marshal.AllocHGlobal(s32_Size);
+                Marshal.Copy(u8_Bytes, 0, p_Mem, s32_Read);
+                T i_Struct = (T)Marshal.PtrToStructure(p_Mem, typeof(T));
+                Marshal.FreeHGlobal(p_Mem);
+                return i_Struct;
+            }
+
+            // ======================================================================================
+
+            /// <summary>
+            /// Read a specific count of bytes from the stream
+            /// </summary>
+            public Byte[] ReadData(int s32_ByteCount)
+            {
+                Byte[] u8_Data = new Byte[s32_ByteCount];
+                int s32_Read = Read(u8_Data, 0, s32_ByteCount);
+                
+                #if TRACE_OUTPUT
+                    TraceLine("Read", s32_ByteCount, "Data", BytesToAscii(u8_Data, s32_Read));
+                #endif
+
+                if (s32_Read != s32_ByteCount) Throw("Incomplete response from the device.");
+                return u8_Data;
+            }
+        }
+
+        #endregion
+
+        #region cIntParam
+
+        /// <summary>
+        /// Used to send an integer to the instrument
+        /// </summary>
+        [StructLayout(LayoutKind.Sequential, Pack=1)]
+        class cIntParam : ICmdParam
+        {
+            public int ms32_Value;
+
+            public cIntParam()
+            {
+            }
+
+            public cIntParam(int s32_Value)
+            {
+                ms32_Value = Revert(s32_Value);
+            }
+
+            public int GetTxByteCount()
+            {
+                return 4;
+            }
+        }
+
+        #endregion
+
+        #region cDataParam
+
+        /// <summary>
+        /// Used to send variable-length byte arrays to the instrument (ASCII strings)
+        /// </summary>
+        [StructLayout(LayoutKind.Sequential, Pack=1)]
+        class cDataParam : ICmdParam
+        {
+            const int BUF_SIZE = 1024;
+
+            public int ms32_DataLength;
+            [MarshalAs(UnmanagedType.ByValArray, SizeConst= BUF_SIZE)]
+            public Byte[] mu8_Buffer = new Byte[BUF_SIZE];
+
+            public int GetTxByteCount()
+            {
+                int s32_Chars = Revert(ms32_DataLength);
+                s32_Chars = ((s32_Chars + 3) / 4) * 4; // always send multiple of 4 bytes
+                return s32_Chars + 4;
+            }
+
+            public void StoreData(Byte[] u8_Data)
+            {
+                Debug.Assert(u8_Data.Length <= BUF_SIZE, "Programming Error: Max data length is "+BUF_SIZE+" byte");
+
+                ms32_DataLength = Revert(u8_Data.Length);
+                Array.Copy(u8_Data, mu8_Buffer, u8_Data.Length);
+            }
+        }
+
+        #endregion
+
+        #region cRmtPrcCallParam, cRmtPrcCallReply
+
+        /// <summary>
+        /// Sent as the first part of every Remote Procedure Call Request
+        /// </summary>
+        [StructLayout(LayoutKind.Sequential, Pack=1)]
+        class cRmtPrcCallParam : ICmdParam
+        {
+            public int ms32_MessageID;
+            public int ms32_MessageType; // eMesgType
+            public int ms32_RpcVersion;
+            // ---------------------------
+            public int ms32_Program;
+            public int ms32_ProgramVersion;
+            public int ms32_Procedure;   // eProcedure
+            // ---------------------------
+            public int ms32_AuthType;    // always zero
+            public int ms32_AuthData;    // always zero
+            public int ms32_VerificType; // always zero
+            public int ms32_VerificData; // always zero
+
+            public int GetTxByteCount()
+            {
+                return 40; // 10 integers
+            }
+        }
+
+        /// <summary>
+        /// Received as the first part of every Remote Procedure Call Reply
+        /// </summary>
+        [StructLayout(LayoutKind.Sequential, Pack=1)]
+        class cRmtPrcCallReply
+        {
+            public int ms32_MessageID;   // same as cRmtPrcCallParam.ms32_MessageID
+            public int ms32_MessageType; // eMesgType
+            // ---------------------------
+            public int ms32_ReplyState;  // eReplyState
+            public int ms32_VerificType; // always zero
+            public int ms32_VerificData; // always zero
+            public int ms32_AcceptState; // eAcceptState
+        }
+
+        #endregion
+
+        #region cGetPortParam
+
+        /// <summary>
+        /// Sent as the second part of the request eProcedure.Get_Port
+        /// </summary>
+        [StructLayout(LayoutKind.Sequential, Pack=1)]
+        class cGetPortParam : ICmdParam
+        {
+            public int ms32_Program;
+            public int ms32_ProgramVersion;
+            public int ms32_Protocol;
+            public int ms32_Port;        // always zero
+
+            public cGetPortParam(int s32_Program, int s32_ProgramVersion, ProtocolType e_Protocol)
+            {
+                ms32_Program        = Revert(s32_Program);
+                ms32_ProgramVersion = Revert(s32_ProgramVersion);
+                ms32_Protocol       = Revert((int)e_Protocol);
+            }
+
+            public int GetTxByteCount()
+            {
+                return 16; // 4 integers
+            }
+        }
+
+        #endregion
+
+        #region cCreateLinkParam, cCreateLinkReply
+
+        /// <summary>
+        /// Sent as the second part of the request eProcedure.Create_Link
+        /// </summary>
+        [StructLayout(LayoutKind.Sequential, Pack=1)]
+        class cCreateLinkParam : ICmdParam
+        {
+            public int        ms32_ClientID;
+            public int        ms32_LockDevice;  // bool (0 or 1)
+            public int        ms32_LockTimeout;
+            public cDataParam mi_DeviceName = new cDataParam();
+
+            public cCreateLinkParam(int s32_ClientID, String s_DeviceName)
+            {
+                ms32_ClientID = Revert(s32_ClientID);
+                mi_DeviceName.StoreData(Encoding.ASCII.GetBytes(s_DeviceName));
+            }
+
+            public int GetTxByteCount()
+            {
+                return 12 + mi_DeviceName.GetTxByteCount();
+            }
+        }
+
+        /// <summary>
+        /// Received as the second part of the reply to eProcedure.Create_Link
+        /// </summary>
+        [StructLayout(LayoutKind.Sequential, Pack=1)]
+        class cCreateLinkReply
+        {
+            public int ms32_ErrorCode;   // eVxiError
+            public int ms32_LinkID;
+            public int ms32_AbortPort;   // Rigol uses port 619, used for procedure Device_Abort
+            public int ms32_MaxRecvSize;
+        }
+
+        #endregion
+
+        #region cDeviceWriteParam, cDeviceWriteReply
+
+        /// <summary>
+        /// Sent as the second part of the request eProcedure.Device_Write
+        /// </summary>
+        [StructLayout(LayoutKind.Sequential, Pack=1)]
+        class cDeviceWriteParam : ICmdParam
+        {
+            public int        ms32_LinkID;
+            public int        ms32_IoTimeout;
+            public int        ms32_LockTimeout;
+            public int        ms32_WriteFlags;   // eWriteFlags
+            public cDataParam mi_Data = new cDataParam();
+
+            public cDeviceWriteParam(int s32_LinkID, Byte[] u8_Data)
+            {
+                ms32_LinkID     = Revert(s32_LinkID);
+                ms32_IoTimeout  = Revert(2000);
+                ms32_WriteFlags = Revert((int)eWriteFlags.End); // SCPI commands are always terminated with End char "\n"
+                mi_Data.StoreData(u8_Data);
+            }
+
+            public int GetTxByteCount()
+            {
+                return 16 + mi_Data.GetTxByteCount();
+            }
+        }
+
+        /// <summary>
+        /// Received as the second part of the reply to eProcedure.Device_Write
+        /// </summary>
+        [StructLayout(LayoutKind.Sequential, Pack=1)]
+        class cDeviceWriteReply
+        {
+            public int ms32_ErrorCode;   // eVxiError
+            public int ms32_Size;
+        }
+
+        #endregion
+
+        #region cDeviceReadParam, cDeviceReadReply
+
+        /// <summary>
+        /// Sent as the second part of the request eProcedure.Device_Read
+        /// </summary>
+        [StructLayout(LayoutKind.Sequential, Pack=1)]
+        class cDeviceReadParam : ICmdParam
+        {
+            public int ms32_LinkID;
+            public int ms32_RequSize;       // bytes requested from device
+            public int ms32_IoTimeout;
+            public int ms32_LockTimeout;
+            public int ms32_WriteFlags;     // eWriteFlags
+            public int ms32_TermChar;       // valid if eWriteFlags.TermCharSet is set
+            
+            public cDeviceReadParam(int s32_LinkID)
+            {
+                ms32_LinkID    = Revert(s32_LinkID);
+                ms32_RequSize  = Revert(100000000); // 100 MB = No buffer limit
+                ms32_IoTimeout = Revert(2000);
+                ms32_TermChar  = Revert('\n');
+            }
+
+            public int GetTxByteCount()
+            {
+                return 24;
+            }
+        }
+
+        /// <summary>
+        /// Received as the second part of the reply to eProcedure.Device_Read
+        /// </summary>
+        [StructLayout(LayoutKind.Sequential, Pack=1)]
+        class cDeviceReadReply
+        {
+            public int ms32_ErrorCode;   // eVxiError
+            public int ms32_Reason;      // eReadFlags
+            public int ms32_ByteCount;
+            // followed by data
+        }
+
+        #endregion
+
+        const int UDP_RESPONSE_TIMEOUT = 1500; // normally responses come in less than 15 ms
+        const int PORT_MAPPER_PORT     = 111;
+        const int RPC_VERSION          = 2;
+        const int PORT_MAPPER_PROGRAM  = 100000;
+        const int PORT_MAPPER_VERSION  = 2;
+        const int DEVICE_CORE_PROGRAM  = 0x607AF;
+        const int DEVICE_CORE_VERSION  = 1;
+        const int FLAG_LAST_FRAGMENT   = int.MinValue; // 0x80000000
+        const int WSAETIMEDOUT         = 10060;        // SocketException
+
+        Socket    mi_Socket;
+        VxiStream mi_RxStream    = new VxiStream();
+        Byte[]    mu8_RxBuffer   = new Byte[0x8000];      // 32 kB is far more than the length of TCP packets
+        int       ms32_ClientID  = 0x4F737A69;            // ASCII == "Oszi"
+        int       ms32_MessageID = Environment.TickCount; // set a random start value, incremented with each message
+        int       ms32_LinkID;                            // reply from procedure Create_Link, Rigol uses LinkID = 0
+        int       ms32_MaxRecvSize;                       // reply from procedure Create_Link
+        int       ms32_AbortPort;                         // reply from procedure Create_Link
+        bool      mb_LinkCreated;                         // set in CreateLink()
+
+        public void Dispose()
+        {
+            if (mi_Socket != null)
+            {
+                DestroyLink(); // does not throw
+
+                mi_Socket.Dispose();
+                mi_Socket = null;
+            }
+        }
+
+        /// <summary>
+        /// Send an UDP broadcast request to port 111 to find connected VXI devices.
+        /// returns all IP Addresses that have responded.
+        /// </summary>
+        public void EnumerateVxiDevices(ComboBox i_ComboDevices, bool b_AddPort = false)
+        {
+            #if TRACE_OUTPUT
+                Debug.Print("> FindDevices()");
+            #endif
+
+            if (mi_Socket != null)
+            {
+                Debug.Assert(false, "Programming Error: A connection is already established.");
+                Dispose(); // Close connection
+            }
+
+            mi_Socket = new Socket(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp);
+            mi_Socket.ReceiveTimeout  = UDP_RESPONSE_TIMEOUT; // UDP response delay is less than 15 ms
+            mi_Socket.SendTimeout     = 1000;
+            mi_Socket.EnableBroadcast = true;
+
+            cGetPortParam i_Param = new cGetPortParam(DEVICE_CORE_PROGRAM, DEVICE_CORE_VERSION, ProtocolType.Tcp);
+            Byte[] u8_TxPack = BuildRpcTxPacket(eProcedure.Get_Port, i_Param);
+
+            IPEndPoint i_TxEndPoint = new IPEndPoint(IPAddress.Broadcast, PORT_MAPPER_PORT);
+            mi_Socket.SendTo(u8_TxPack, i_TxEndPoint);
+
+            i_ComboDevices.Items.Clear();
+            try
+            {
+                while (true) // run until timeout exception is thrown
+                {
+                    EndPoint i_RxEndPoint = new IPEndPoint(IPAddress.Any, 0);
+                    int s32_Read = mi_Socket.ReceiveFrom(mu8_RxBuffer, ref i_RxEndPoint);
+                    String s_IP  = ((IPEndPoint)i_RxEndPoint).Address.ToString();
+
+                    mi_RxStream.SetLength(0);
+                    mi_RxStream.Write(mu8_RxBuffer, 0, s32_Read);
+
+                    String s_Error = CheckRpcRxPacket();
+                    if (s_Error != null)
+                    {
+                        #if TRACE_OUTPUT
+                            Debug.Print(s_Error);
+                        #endif
+                    }
+                    else if (b_AddPort)
+                    {
+                        int s32_Port = mi_RxStream.ReadInt32("Port");
+                        if (s32_Port > 0 && s32_Port < UInt16.MaxValue)
+                            s_IP += " : " + s32_Port;
+                    }
+
+                    i_ComboDevices.Items.Add(s_IP);
+
+                    #if TRACE_OUTPUT
+                        Debug.Print("    Response from " + s_IP);
+                    #endif
+                }
+            }
+            catch (SocketException Ex)
+            {
+                // Throw any error except timeout
+                if (Ex.ErrorCode != WSAETIMEDOUT)
+                    throw Ex;
+            }
+
+            #if TRACE_OUTPUT
+                Debug.Print("< FindDevices()");
+            #endif
+
+            Dispose();
+
+            if (i_ComboDevices.Items.Count > 0)
+                i_ComboDevices.SelectedIndex = 0;
+        }
+
+        /// <summary>
+        /// 连接远端 VXI-11 设备，如果端口为 0 则先通过端口映射器查询实际控制端口。
+        /// IP = "192.168.0.240", Port = 618 --> Connect directly to the control port 618.
+        /// IP = "192.168.0.240", Port = 0   --> Request the control port from the portmapper and connect to it.
+        /// </summary>
+        public void ConnectDevice(IPAddress i_IpAddress, UInt16 u16_TcpPort)
+        {
+            if (u16_TcpPort == 0 || u16_TcpPort == PORT_MAPPER_PORT)
+            {
+                AsyncConnect(i_IpAddress, PORT_MAPPER_PORT);
+                u16_TcpPort = GetControlPort();
+            }
+            AsyncConnect(i_IpAddress, u16_TcpPort);
+        }
+
+        void AsyncConnect(IPAddress i_IpAddress, UInt16 u16_TcpPort)
+        {
+            #if TRACE_OUTPUT
+                Debug.Print("> AsyncConnect({0} : {1})", i_IpAddress, s32_Port);
+            #endif
+
+            Dispose(); // disconnect if connected
+
+            mi_Socket = ScpiClient.ConnectTcpSocketAsync(i_IpAddress, u16_TcpPort);
+
+            #if TRACE_OUTPUT
+                Debug.Print("< AsyncConnect()");
+            #endif
+        }
+
+        // ====================================================================================================
+
+        /// <summary>
+        /// Get the VXI Control Port of the device by calling procedure Get_Port on the port mapper port 111.
+        /// Rigol uses port 618.
+        /// </summary>
+        UInt16 GetControlPort()
+        {
+            #if TRACE_OUTPUT
+                Debug.Print("> GetControlPort()");
+            #endif
+
+            cGetPortParam i_Param = new cGetPortParam(DEVICE_CORE_PROGRAM, DEVICE_CORE_VERSION, ProtocolType.Tcp);
+            RpcCall(eProcedure.Get_Port, i_Param);
+
+            int s32_Port = mi_RxStream.ReadInt32("Port");
+            if (s32_Port <= 0 || s32_Port > UInt16.MaxValue)
+                Throw("Received invalid control Port = zero");
+
+            #if TRACE_OUTPUT
+                Debug.Print("< GetControlPort() --> Port= {0}", s32_Port);
+            #endif
+            return (UInt16)s32_Port;
+        }
+
+        /// <summary>
+        /// DeviceName = "gpib0", "inst0",... depends on the manufacturer.
+        /// ATTENTION: Device name is CASE SENSITIVE!
+        /// 建立逻辑 Link，相当于在仪器内部选择一个具体的 SCPI 终端。
+        /// A link is a "connection" over TCP to a "device" inside the instrument.
+        /// There may be multiple "devices" inside one instrument, each having it's own name.
+        /// </summary>
+        public void CreateLink(String s_DeviceName)
+        {
+            #if TRACE_OUTPUT
+                Debug.Print("> CreateLink(Device= '{0}')", s_DeviceName);
+            #endif
+
+            DestroyLink();
+
+            cCreateLinkParam i_Param = new cCreateLinkParam(ms32_ClientID, s_DeviceName);
+            RpcCall(eProcedure.Create_Link, i_Param);
+
+            cCreateLinkReply i_Reply = mi_RxStream.ReadStruct<cCreateLinkReply>();
+            eVxiError e_Error = (eVxiError)Revert(i_Reply.ms32_ErrorCode);
+            if (e_Error != eVxiError.Success)
+                Throw("Error connecting to VXI link '" + s_DeviceName + "':  " + e_Error.ToString().Replace('_', ' '));
+
+            ms32_LinkID      = Revert(i_Reply.ms32_LinkID);      // Rigol sends Link ID = zero!
+            ms32_MaxRecvSize = Revert(i_Reply.ms32_MaxRecvSize); // Rigol sends 1500 byte
+            ms32_AbortPort   = Revert(i_Reply.ms32_AbortPort);   // Rigol sends port 619, used for procedure Device_Abort
+            mb_LinkCreated   = true;
+
+            #if TRACE_OUTPUT
+                Debug.Print("< CreateLink() --> LinkID= {0}, MaxRecvSize= {1}, AbortPort= {2}", ms32_LinkID, ms32_MaxRecvSize, ms32_AbortPort);
+            #endif
+        }
+
+        /// <summary>
+        /// Does not throw
+        /// </summary>
+        void DestroyLink()
+        {
+            if (!mb_LinkCreated)
+                return;
+
+            #if TRACE_OUTPUT
+                Debug.Print("> DestroyLink(LinkID= {0})", ms32_LinkID);
+            #endif
+
+            try
+            {
+                cIntParam i_Param = new cIntParam(ms32_LinkID); // Rigol uses LinkID = 0
+                RpcCall(eProcedure.Destroy_Link, i_Param);
+
+                #if TRACE_OUTPUT
+                    // Rigol does not return an error if a link is destroyed that does not exist
+                    eVxiError e_Error = (eVxiError)mi_RxStream.ReadInt32("ErrorFlags");
+                    if (e_Error != eVxiError.Success)
+                        Debug.Print("*** Error destroying link: " + e_Error.ToString().Replace('_', ' '));
+                #endif
+            }
+            catch {}
+
+            ms32_LinkID      = 0; 
+            ms32_MaxRecvSize = 0;
+            ms32_AbortPort   = 0;
+            mb_LinkCreated   = false;
+
+            #if TRACE_OUTPUT
+                Debug.Print("< DestroyLink()");
+            #endif
+        }
+
+        /// <summary>
+        /// 发送命令或波形数据到设备（常见为 ASCII 指令如 "*IDN?\n"）。
+        /// Send a data packet to the device (normally an ASCII string like "*IDN?\n")
+        /// </summary>
+        public void DeviceWrite(Byte[] u8_Data)
+        {
+            #if TRACE_OUTPUT
+                Debug.Print("> DeviceWrite(Data= {0} byte, Ascii= {1})", u8_Data.Length, BytesToAscii(u8_Data, u8_Data.Length));
+            #endif
+
+            Debug.Assert(mb_LinkCreated,                     "Programming Error: You must first create a link");
+            Debug.Assert(u8_Data.Length <= ms32_MaxRecvSize, "Programming Error: Device allows max data of "+ms32_MaxRecvSize+" byte");
+
+            cDeviceWriteParam i_Param = new cDeviceWriteParam(ms32_LinkID, u8_Data);
+            RpcCall(eProcedure.Device_Write, i_Param);
+
+            cDeviceWriteReply i_Reply = mi_RxStream.ReadStruct<cDeviceWriteReply>();
+            eVxiError e_Error = (eVxiError)Revert(i_Reply.ms32_ErrorCode);
+            if (e_Error != eVxiError.Success)
+                Throw("Error writing to device:  " + e_Error.ToString().Replace('_', ' '));
+
+            #if TRACE_OUTPUT
+                Debug.Print("< DeviceWrite()");
+            #endif
+        }
+
+        /// <summary>
+        /// 从设备接收 ASCII 或波形数据，直到服务端声明结束。
+        /// Receive data from the device (ASCII responses or Waveform data)
+        /// </summary>
+        public Byte[] DeviceRead(int s32_Timeout)
+        {
+            #if TRACE_OUTPUT
+                Debug.Print("> DeviceRead()");
+            #endif
+
+            Debug.Assert(mb_LinkCreated, "Programming Error: You must first create a link");
+
+            mi_Socket.ReceiveTimeout = s32_Timeout;
+            MemoryStream i_ReceivedData = new MemoryStream();
+            while (true)
+            {
+                cDeviceReadParam i_Param = new cDeviceReadParam(ms32_LinkID);
+                RpcCall(eProcedure.Device_Read, i_Param);
+
+                cDeviceReadReply i_Reply = mi_RxStream.ReadStruct<cDeviceReadReply>();
+                eVxiError e_Error = (eVxiError)Revert(i_Reply.ms32_ErrorCode);
+                if (e_Error == eVxiError.IO_Timeout)
+                    Throw("Timeout. No response from the oscilloscope.\nRead the Help file!", true);
+
+                if (e_Error != eVxiError.Success)
+                    Throw("Error reading from device:  " + e_Error.ToString().Replace('_', ' '));
+
+                int s32_ByteCount  =             Revert(i_Reply.ms32_ByteCount);
+                eReadFlags e_Flags = (eReadFlags)Revert(i_Reply.ms32_Reason);
+
+                Byte[] u8_Data = mi_RxStream.ReadData(s32_ByteCount); // writes to Trace
+                i_ReceivedData.Write(u8_Data, 0, u8_Data.Length);
+
+                #if TRACE_OUTPUT
+                    Debug.Print("    Reason= {0}", e_Flags);
+                #endif
+
+                if ((e_Flags & eReadFlags.End) > 0) break;
+
+                // If the flag eReadFlags.End is not set, more data must be received.
+                // After requesting 250.000 bytes, Rigol sends 102.400 + 102.400 + 45.212 bytes.
+                #if TRACE_OUTPUT
+                    Debug.Print("    --------- Get Next Block ----------");
+                #endif
+            }
+
+            #if TRACE_OUTPUT
+                Debug.Print("< DeviceRead() --> total bytes= " + i_ReceivedData.Length);
+            #endif
+            return i_ReceivedData.ToArray();
+        }
+
+        // ====================================================================================================
+
+        /// <summary>
+        /// Execute a Remote Procedure Call in the instrument.
+        /// Any received data that comes behind the RPC Reply structure (cRmtPrcCallReply) remains in mi_RxStream.
+        /// </summary>
+        void RpcCall(eProcedure e_Procedure, ICmdParam i_Param)
+        {
+            Debug.Assert(mi_Socket.ProtocolType == ProtocolType.Tcp, "Programming Error: RpcCall() requires a TCP connection.");
+
+            // ------ Send -------
+
+            Byte[] u8_TxPack = BuildRpcTxPacket(e_Procedure, i_Param);
+            #if TRACE_OUTPUT
+                TraceLine("Send", u8_TxPack.Length, "TX Packet", "");
+            #endif
+            mi_Socket.Send(u8_TxPack, 0, u8_TxPack.Length, SocketFlags.None);
+
+            // ----- Receive -----
+
+            mi_RxStream.SetLength(0);
+            bool b_Finished = false;
+            while (!b_Finished)
+            {
+                try
+                {
+                    int s32_Read = mi_Socket.Receive(mu8_RxBuffer, 4, SocketFlags.None);
+                    if (s32_Read != 4) Throw("Incomplete header received");
+                }
+                catch (SocketException Ex)
+                {
+                    // In case of Timeout the SocketException must be converted into a TimeoutException. 
+                    if (Ex.ErrorCode == WSAETIMEDOUT)
+                        Throw("Timeout. No response from the oscilloscope.\nRead the Help file!", true);
+
+                    #if TRACE_OUTPUT
+                        Debug.Print("*** " + Ex.Message);
+                    #endif
+                    throw Ex;
+                }
+
+                int s32_Header = ToInteger(mu8_RxBuffer);
+
+                // b_Finished == false --> more data will follow
+                b_Finished = (s32_Header & FLAG_LAST_FRAGMENT) != 0;
+
+                #if TRACE_OUTPUT
+                    String s_Fragment = b_Finished ? " (Last)" : " (Fragment)";
+                    TraceLine("Recv", 4, "Header", s32_Header.ToString("X8") + s_Fragment);
+                #endif
+
+                int s32_RxLen = s32_Header & 0x7FFFFFFF; // Rigol sends TCP packets of 396 byte
+                while (s32_RxLen > 0)
+                {
+                    int s32_Read = mi_Socket.Receive(mu8_RxBuffer, s32_RxLen, SocketFlags.None);
+                    mi_RxStream.Write(mu8_RxBuffer, 0, s32_Read);
+
+                    #if TRACE_OUTPUT
+                        TraceLine("Recv", s32_Read, "RX Data", "");
+                    #endif
+
+                    // Sometimes only 256 byte of the 396 byte arrive --> loop once more
+                    s32_RxLen -= s32_Read;
+                }
+            }
+
+            // ----- Check cRmtPrcCallReply -----
+
+            String s_Error = CheckRpcRxPacket();
+            if (s_Error != null)
+                Throw(s_Error);
+        }
+
+        Byte[] BuildRpcTxPacket(eProcedure e_Procedure, ICmdParam i_Param)
+        {
+            ms32_MessageID ++;
+
+            cRmtPrcCallParam i_Rpc = new cRmtPrcCallParam();
+            VxiStream i_TxStream   = new VxiStream();
+
+            // The header contains the flag FLAG_LAST_FRAGMENT and the count of bytes that follow.
+            // If the command is broadcast over UDP the header is omitted.
+            if (mi_Socket.ProtocolType == ProtocolType.Tcp)
+            {
+                int s32_Header = FLAG_LAST_FRAGMENT | (i_Rpc.GetTxByteCount() + i_Param.GetTxByteCount());
+                i_TxStream.WriteInt32(s32_Header, "Header");
+            }
+
+            i_Rpc.ms32_MessageID   = Revert(ms32_MessageID);
+            i_Rpc.ms32_MessageType = Revert((int)eMesgType.Call);
+            i_Rpc.ms32_RpcVersion  = Revert(RPC_VERSION); 
+            i_Rpc.ms32_Procedure   = Revert((int)e_Procedure);
+
+            if (e_Procedure == eProcedure.Get_Port)
+            {
+                i_Rpc.ms32_Program        = Revert(PORT_MAPPER_PROGRAM);
+                i_Rpc.ms32_ProgramVersion = Revert(PORT_MAPPER_VERSION);
+            }
+            else
+            {
+                i_Rpc.ms32_Program        = Revert(DEVICE_CORE_PROGRAM);
+                i_Rpc.ms32_ProgramVersion = Revert(DEVICE_CORE_VERSION);    
+            }
+
+            i_TxStream.WriteStruct(i_Rpc);
+            i_TxStream.WriteStruct(i_Param);
+            return i_TxStream.ToArray();
+        }
+
+        /// <summary>
+        /// Does not throw. Returns a string with an error message
+        /// </summary>
+        String CheckRpcRxPacket()
+        {
+            mi_RxStream.Position = 0;
+            cRmtPrcCallReply i_RpcReply = mi_RxStream.ReadStruct<cRmtPrcCallReply>();
+
+            if (Revert(i_RpcReply.ms32_MessageID) != ms32_MessageID)
+                return "Received RPC response with invalid message ID";
+
+            if (Revert(i_RpcReply.ms32_MessageType) != (int)eMesgType.Reply)
+                return "Received RPC response with invalid message type";
+
+            eAcceptState e_Accept = (eAcceptState)Revert(i_RpcReply.ms32_AcceptState);
+            if (e_Accept != eAcceptState.Success)
+                return "RPC Error response: " + e_Accept.ToString().Replace('_', ' ');
+
+            if (Revert(i_RpcReply.ms32_ReplyState) != (int)eReplyState.Accepted)
+                return "The RPC command was not accepted";
+
+            return null;
+        }
+
+        // ================================== Helper ====================================
+
+        /// <summary>
+        /// Make integer big endian
+        /// </summary>
+        static int Revert(int s32_Value)
+        {
+            int s32_Return = 0;
+            s32_Return |= (Byte)(s32_Value         >> 24);
+            s32_Return |= (s32_Value & 0x00FF0000) >>  8;
+            s32_Return |= (s32_Value & 0x0000FF00) <<  8;
+            s32_Return |= (s32_Value & 0x000000FF) << 24;
+            return s32_Return;
+        }
+
+        /// <summary>
+        /// Create a big-endian integer from the given bytes
+        /// </summary>
+        static int ToInteger(Byte[] u8_Data)
+        {
+            int s32_Return = 0;
+            s32_Return |= (int)u8_Data[0] << 24;
+            s32_Return |= (int)u8_Data[1] << 16;
+            s32_Return |= (int)u8_Data[2] <<  8;
+            s32_Return |= (int)u8_Data[3];
+            return s32_Return;
+        }
+
+        /// <summary>
+        /// The TimeoutException has a sepcial treatment: 
+        /// It is is handled in PanelRigol.SendManualCommand() when manually sending an invalid command.
+        /// </summary>
+        static void Throw(String s_Message, bool b_Timeout = false)
+        {
+            #if TRACE_OUTPUT
+                Debug.Print("*** " + s_Message);
+            #endif
+
+            if (b_Timeout) throw new TimeoutException(s_Message);
+            else           throw new Exception(s_Message);
+        }
+
+        // ================================= Debug ======================================
+
+    #if TRACE_OUTPUT
+
+        /// <summary>
+        /// Print a line like "    Store  24 byte cCreateLinkParam 4F737A69 00000000 00000000 00000005 696E7374 30000000"
+        /// </summary>
+        static void TraceLine(String s_Action, int s32_Bytes, String s_Debug, String s_Data)
+        {
+            Debug.Print("    {0} {1,6} byte {2} {3}", s_Action.PadRight(5), s32_Bytes, s_Debug.PadRight(17), s_Data);
+        }
+
+        /// <summary>
+        /// returns max. 100 bytes as ASCII
+        /// </summary>
+        static String BytesToAscii(Byte[] u8_Data, int s32_Count)
+        {
+            int s32_MaxLen = Math.Min(100, s32_Count);
+            String s_Ascii = Encoding.ASCII.GetString(u8_Data, 0, s32_MaxLen);
+            if (s32_MaxLen < s32_Count) s_Ascii += " ....";
+            return '"' + s_Ascii.Replace("\r", "<CR>").Replace("\n", "<LF>") + '"';
+        }
+
+        /// <summary>
+        /// returns "00112233 44556677 AABBCCDD"
+        /// </summary>
+        static String BytesToHex(Byte[] u8_Data, int s32_Count)
+        {
+            StringBuilder i_Hex = new StringBuilder();
+            for (int i=0; i<s32_Count; i++)
+            {
+                if (i > 0 && (i & 3) == 0)
+                {
+                    if (i_Hex.Length > 200)
+                    {
+                        i_Hex.Append(" ....");
+                        break;
+                    }
+                    i_Hex.Append(" ");
+                }
+                i_Hex.AppendFormat("{0:X2}", u8_Data[i]);
+            }
+            return i_Hex.ToString();
+        }
+    #endif
+    }
+}
+


### PR DESCRIPTION
## Summary
- 新增 `ScpiTransport` 类库工程，针对 .NET Framework 4.8 与 .NET 7.0-windows 提供统一的 SCPI 通讯核心
- 提供 USB 设备枚举、USBTMC 读写封装与 VXI-11/TCP 会话实现，可直接复用原有命令处理逻辑并加入中文注释

## Testing
- 未执行（容器环境缺少 .NET 运行时）

------
https://chatgpt.com/codex/tasks/task_e_68d622b636d08324adcee289667224be